### PR TITLE
#4: Grant SSH access to traffic originating from a given AWS security group (closes #4)

### DIFF
--- a/security_group.tf
+++ b/security_group.tf
@@ -2,13 +2,24 @@ resource "aws_security_group" "sg" {
   name = "${var.project_name}"
 }
 
-resource "aws_security_group_rule" "ssh" {
+resource "aws_security_group_rule" "ssh_cidr" {
   type = "ingress"
   protocol = "tcp"
   security_group_id = "${aws_security_group.sg.id}"
   from_port = 22
   to_port = 22
   cidr_blocks = "${var.in_cidr_blocks}"
+}
+
+resource "aws_security_group_rule" "ssh_source_security_group" {
+  count = "${length(var.in_source_security_group) > 0 ? 1 : 0}"
+
+  type = "ingress"
+  protocol = "tcp"
+  security_group_id = "${aws_security_group.sg.id}"
+  from_port = 22
+  to_port = 22
+  source_security_group_id = "${var.in_source_security_group}"
 }
 
 resource "aws_security_group_rule" "out_all" {

--- a/variables.tf
+++ b/variables.tf
@@ -42,10 +42,12 @@ variable init_script {
 }
 
 variable in_open_ports {
+  type = "list"
   default = []
 }
 
 variable in_cidr_blocks {
+  type = "list"
   default = ["0.0.0.0/0"]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -49,6 +49,12 @@ variable in_cidr_blocks {
   default = ["0.0.0.0/0"]
 }
 
+variable in_source_security_group {
+  description = "Security group to receive SSH access"
+  type = "string"
+  default = ""
+}
+
 variable disk_utilization_alarm_threshold {
   description = "disk occupation alarm threshold (% of disk utilization)"
   default = "80"


### PR DESCRIPTION
Closes #4

Provides an optional `in_source_security_group` variable to the module to be able to grant SSH access to traffic originating from a given AWS security group.

Also added a couple of minor stylistic fixes.

## Test Plan

### tests performed
- manual deployment of a dummy template:
  - deployed without `in_source_security_group` set => `terraform plan` and `terraform apply` deploy correctly with no security group rule based on source_security_group_id
  - added `BROKEN` as `in_source_security_group` => `terraform` plan fails
  - added a working security group id as `in_source_security_group` => `terraform plan` and `terraform apply` deploy correctly a new security group rule base on the given source_security_group_id

### tests not performed (domain coverage)
N/A
