### PR TITLE
Module flexibility improvements

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -69,7 +69,7 @@ resource "aws_instance" "instance" {
 
   provisioner "remote-exec" {
     inline = [
-      "docker login quay.io -u dontspamus -p ${var.quay_password}",
+      "docker login quay.io -u ${var.quay_username} -p ${var.quay_password}",
       "chmod +x ./init.sh",
       "docker run -itd --restart always quay.io/buildo/bellosguardo:${var.bellosguardo_target}",
       "./init.sh"

--- a/main.tf
+++ b/main.tf
@@ -106,6 +106,8 @@ variable "bellosguardo_sns_topic_arn" {
 }
 
 resource "aws_route53_record" "dns" {
+  count = "${length(var.zone_id) > 0 && length(var.host_name) > 0 ? 1 : 0}"
+
   zone_id = "${var.zone_id}"
   name = "${var.host_name}"
   type = "A"

--- a/variables.tf
+++ b/variables.tf
@@ -26,10 +26,12 @@ variable ssh_key_name {
 
 variable zone_id {
   description = "Route53 Zone ID"
+  default = ""
 }
 
 variable host_name {
   description = "DNS host name"
+  default = ""
 }
 
 variable quay_username {

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,11 @@ variable host_name {
   description = "DNS host name"
 }
 
+variable quay_username {
+  description = "Quay username"
+  default = "dontspamus"
+}
+
 variable quay_password {
   description = "Quay password"
 }


### PR DESCRIPTION
A few improvement for correctness and flexibility:
* allow to provide a Quay.io username (not hardcoding dontspamus);
* create a DNS record if and only if a zone ID and a host_name is provided;
* Fix bug where setting port 22 in `in_open_ports` lead to duplicate aws_security_group_rule.