### PR TITLE
#7: When creating an instance, `apt-get upgrade` can get stuck on a prompt (closes #7)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,7 @@ resource "aws_instance" "instance" {
       "sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D",
       "echo \"deb https://apt.dockerproject.org/repo ubuntu-xenial main\" | sudo tee /etc/apt/sources.list.d/docker.list",
       "sudo apt-get update",
-      "sudo apt-get upgrade -y",
+      "sudo DEBIAN_FRONTEND=noninteractive apt-get upgrade -y -o DPkg::options::=\"--force-confdef\" -o DPkg::options::=\"--force-confold\"",
       "sudo apt-get install -y docker-engine",
       "sudo service docker start",
       "sudo usermod -aG docker $USER",


### PR DESCRIPTION
Closes [#2522339](https://buildo.kaiten.io/space/[object Object]/card/2522339)

⚠️ The line above was added during the automatic migration of all github project issues to Kaiten. The old GH issue link is kept here for reference (it is now deprecated, continue follow the original issue on Kaiten).

Closes #7

I applied the solution proposed in https://devops.stackexchange.com/questions/1139/how-to-avoid-interactive-dialogs-when-running-apt-get-upgrade-y-in-ubuntu-16, replacing
```
sudo apt-get upgrade -y
```
with
```
sudo DEBIAN_FRONTEND=noninteractive apt-get upgrade -yq
```

Possible problem mentioned in the linked question: the upgrade of packages that require interaction might be skipped. (I haven't checked if this is true.)

## Test Plan

I've tried using my local module instead of the released one and instance creation seem to work successfully and terminate quickly.