### PR TITLE
#12: Use string instead of file for variable ssh_private_key

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ resource "aws_instance" "instance" {
   connection {
     host        = self.public_ip
     user        = "ubuntu"
-    private_key = file(var.ssh_private_key)
+    private_key = var.ssh_private_key
   }
 
   provisioner "file" {

--- a/variables.tf
+++ b/variables.tf
@@ -17,7 +17,7 @@ variable volume_size {
 }
 
 variable ssh_private_key {
-  description = "Used to connect to the instance once created"
+  description = "The contents of an SSH key to use for the connection, used to setup the instance once created. Can be loaded from a file on disk using the file function"
   type        = string
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -17,7 +17,7 @@ variable volume_size {
 }
 
 variable ssh_private_key {
-  description = "The contents of an SSH key to use for the connection, used to setup the instance once created. Can be loaded from a file on disk using the file function"
+  description = "The private key material of the key pair associated with the instance"
   type        = string
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,7 @@ variable volume_size {
 
 variable ssh_private_key {
   description = "Used to connect to the instance once created"
+  type        = string
 }
 
 variable ssh_key_name {


### PR DESCRIPTION
Closes [#2520477](https://buildo.kaiten.io/space/32111/card/2520477)

⚠️ The line above was added during the automatic migration of all github project issues to Kaiten. The old GH issue link is kept here for reference (it is now deprecated, continue follow the original issue on Kaiten).

Closes #12

Just so that users of the module are allowed to decide if using a file, with `file(filepath)`, or a simple string