### PR TITLE
#14: Additional policies attached to EC2 instance profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ These resources are always created:
 - A Security Group
     - A Security Group Rule for port 22/tcp
     - A Security Group Rule for each port / port range specified in variable `in_open_ports`
-- A IAM Role called "${var.project_name}-ec2-cloudwatch-role"
-- A IAM Profile called "${var.project_name}-cloudwatch-profile"
+- A IAM Role called "${var.project_name}-instance-profile"
+- A IAM Profile called "${var.project_name}"
 
 These resources are created if their variable is set
 

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ resource "aws_instance" "instance" {
   key_name                    = var.ssh_key_name
   security_groups             = [aws_security_group.sg.name]
   associate_public_ip_address = true
-  iam_instance_profile        = aws_iam_instance_profile.profile.name
+  iam_instance_profile        = aws_iam_instance_profile.instance.name
 
   tags = {
     Name = var.project_name
@@ -60,14 +60,14 @@ resource "aws_route53_record" "dns" {
   records = [aws_instance.instance.public_ip]
 }
 
-resource "aws_iam_role_policy_attachment" "cloudwatch_role_policy_attachment" {
+resource "aws_iam_role_policy_attachment" "instance" {
   for_each = toset(concat(
     ["arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"],
     var.instance_profile_policy_arns,
   ))
 
   policy_arn = each.key
-  role       = aws_iam_role.cloudwatch_role.id
+  role       = aws_iam_role.instance.id
 }
 
 data aws_iam_policy_document "assume_policy" {
@@ -83,15 +83,15 @@ data aws_iam_policy_document "assume_policy" {
   }
 }
 
-resource "aws_iam_role" "cloudwatch_role" {
-  name                  = "${var.project_name}-ec2-cloudwatch-role"
+resource "aws_iam_role" "instance" {
+  name                  = "${var.project_name}-instance-profile"
   force_detach_policies = true
   assume_role_policy    = data.aws_iam_policy_document.assume_policy.json
 }
 
-resource "aws_iam_instance_profile" "profile" {
-  name = "${var.project_name}-cloudwatch-profile"
-  role = aws_iam_role.cloudwatch_role.name
+resource "aws_iam_instance_profile" "instance" {
+  name = var.project_name
+  role = aws_iam_role.instance.name
 }
 
 resource "aws_cloudwatch_metric_alarm" "disk_full" {

--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,12 @@ resource "aws_route53_record" "dns" {
 }
 
 resource "aws_iam_role_policy_attachment" "cloudwatch_role_policy_attachment" {
-  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+  for_each = toset(concat(
+    ["arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"],
+    var.instance_profile_policy_arns,
+  ))
+
+  policy_arn = each.key
   role       = aws_iam_role.cloudwatch_role.id
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -73,3 +73,9 @@ variable cloudwatch_agent_config {
   type    = string
   default = ""
 }
+
+variable instance_profile_policy_arns {
+  description = "A list of IAM policy ARNs to be associated to the instance profile"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
Closes [#2520376](https://buildo.kaiten.io/space/32111/card/2520376)

⚠️ The line above was added during the automatic migration of all github project issues to Kaiten. The old GH issue link is kept here for reference (it is now deprecated, continue follow the original issue on Kaiten).

Closes #14

## Test Plan

### tests performed
- successfully applied a Terraform configuration based on the updated code
- `terraform fmt -check; echo $?` returns 0

### tests not performed (domain coverage)
- complete test of all the features of the module not directly affected by the changes